### PR TITLE
Make shardId and approximateArrivalTime available to Emitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target/
 AwsCredentials.properties
+
+.idea
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>amazon-kinesis-connectors</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Connector Library</name>
-    <version>1.3.0</version>
+    <version>1.3.0-IFLIX1</version>
     <description>The Amazon Kinesis Connector Library helps Java developers integrate Amazon Kinesis with other AWS and non-AWS services.</description>
     <url>https://aws.amazon.com/kinesis</url>
 

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
@@ -159,7 +159,7 @@ public class KinesisConnectorRecordProcessor<T, U> implements IRecordProcessor {
         List<U> unprocessed = new ArrayList<U>(emitItems);
         try {
             for (int numTries = 0; numTries < retryLimit; numTries++) {
-                unprocessed = emitter.emit(new UnmodifiableBuffer<U>(buffer, unprocessed));
+                unprocessed = emitter.emit(new UnmodifiableBuffer<U>(buffer, unprocessed), shardId);
                 if (unprocessed.isEmpty()) {
                     break;
                 }

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
@@ -139,7 +139,12 @@ public class KinesisConnectorRecordProcessor<T, U> implements IRecordProcessor {
 
     private void filterAndBufferRecord(T transformedRecord, Record record) {
         if (filter.keepRecord(transformedRecord)) {
-            buffer.consumeRecord(transformedRecord, record.getData().array().length, record.getSequenceNumber());
+            buffer.consumeRecord(
+                    transformedRecord,
+                    record.getData().array().length,
+                    record.getSequenceNumber(),
+                    record.getApproximateArrivalTimestamp()
+            );
         }
     }
 

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBuffer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBuffer.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.kinesis.connectors;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 
@@ -64,13 +65,23 @@ public class UnmodifiableBuffer<T> implements IBuffer<T> {
     }
 
     @Override
-    public void consumeRecord(T record, int recordBytes, String sequenceNumber) {
+    public void consumeRecord(T record, int recordBytes, String sequenceNumber, Date approximateArrivalTimestamp) {
         throw new UnsupportedOperationException("This is an unmodifiable buffer");
     }
 
     @Override
     public void clear() {
         throw new UnsupportedOperationException("This is an unmodifiable buffer");
+    }
+
+    @Override
+    public Date getFirstApproximateArrivalTimestamp() {
+        return buf.getFirstApproximateArrivalTimestamp();
+    }
+
+    @Override
+    public Date getLastApproximateArrivalTimestamp() {
+        return buf.getLastApproximateArrivalTimestamp();
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/dynamodb/DynamoDBEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/dynamodb/DynamoDBEmitter.java
@@ -60,7 +60,7 @@ public class DynamoDBEmitter implements IEmitter<Map<String, AttributeValue>> {
     }
 
     @Override
-    public List<Map<String, AttributeValue>> emit(final UnmodifiableBuffer<Map<String, AttributeValue>> buffer)
+    public List<Map<String, AttributeValue>> emit(final UnmodifiableBuffer<Map<String, AttributeValue>> buffer, final String shardId)
         throws IOException {
         // Map of WriteRequests to records for reference
         Map<WriteRequest, Map<String, AttributeValue>> requestMap =

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/ElasticsearchEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/elasticsearch/ElasticsearchEmitter.java
@@ -148,7 +148,7 @@ public class ElasticsearchEmitter implements IEmitter<ElasticsearchObject> {
      * loss occurs and simplifies restarting the application once issues have been fixed.
      */
     @Override
-    public List<ElasticsearchObject> emit(UnmodifiableBuffer<ElasticsearchObject> buffer) throws IOException {
+    public List<ElasticsearchObject> emit(final UnmodifiableBuffer<ElasticsearchObject> buffer, final String shardId) throws IOException {
         List<ElasticsearchObject> records = buffer.getRecords();
         if (records.isEmpty()) {
             return Collections.emptyList();

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/impl/BasicMemoryBuffer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/impl/BasicMemoryBuffer.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.kinesis.connectors.impl;
 
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -36,6 +37,9 @@ public class BasicMemoryBuffer<T> implements IBuffer<T> {
 
     private final List<T> buffer;
     private final AtomicLong byteCount;
+
+    private Date firstApproximateArrivalTimestamp;
+    private Date lastApproximateArrivalTimestamp;
 
     private String firstSequenceNumber;
     private String lastSequenceNumber;
@@ -71,11 +75,13 @@ public class BasicMemoryBuffer<T> implements IBuffer<T> {
     }
 
     @Override
-    public void consumeRecord(T record, int recordSize, String sequenceNumber) {
+    public void consumeRecord(T record, int recordSize, String sequenceNumber, Date approximateArrivalTimestamp) {
         if (buffer.isEmpty()) {
             firstSequenceNumber = sequenceNumber;
+            firstApproximateArrivalTimestamp = approximateArrivalTimestamp;
         }
         lastSequenceNumber = sequenceNumber;
+        lastApproximateArrivalTimestamp = approximateArrivalTimestamp;
         buffer.add(record);
         byteCount.addAndGet(recordSize);
     }
@@ -85,6 +91,16 @@ public class BasicMemoryBuffer<T> implements IBuffer<T> {
         buffer.clear();
         byteCount.set(0);
         previousFlushTimeMillisecond = getCurrentTimeMilliseconds();
+    }
+
+    @Override
+    public Date getFirstApproximateArrivalTimestamp() {
+        return firstApproximateArrivalTimestamp;
+    }
+
+    @Override
+    public Date getLastApproximateArrivalTimestamp() {
+        return lastApproximateArrivalTimestamp;
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/interfaces/IBuffer.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/interfaces/IBuffer.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.kinesis.connectors.interfaces;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -67,12 +68,16 @@ public interface IBuffer<T> {
      * @param sequenceNumber
      *        Amazon Kinesis sequence identifier
      */
-    public void consumeRecord(T record, int recordBytes, String sequenceNumber);
+    public void consumeRecord(T record, int recordBytes, String sequenceNumber, Date approximateArrivalTimestamp);
 
     /**
      * Clears the buffer
      */
     public void clear();
+
+    public Date getFirstApproximateArrivalTimestamp();
+
+    public Date getLastApproximateArrivalTimestamp();
 
     /**
      * Get the sequence number of the first record stored in the buffer. Used for bookkeeping and

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/interfaces/IEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/interfaces/IEmitter.java
@@ -39,12 +39,15 @@ public interface IEmitter<T> {
      * 
      * @param buffer
      *        The full buffer of records
+     * @param shardId
+     *        The id of the Kinesis stream shard where the records in the buffer come from. Useful
+     *        for checkpointing or used in filenames.
      * @throws IOException
      *         A failure was reached that is not recoverable, no retry will occur and the fail
      *         method will be called
      * @return A list of records that failed to emit to be retried
      */
-    List<T> emit(UnmodifiableBuffer<T> buffer) throws IOException;
+    List<T> emit(UnmodifiableBuffer<T> buffer, String shardId) throws IOException;
 
     /**
      * This method defines how to handle a set of records that cannot successfully be emitted.

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftBasicEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftBasicEmitter.java
@@ -71,8 +71,8 @@ public class RedshiftBasicEmitter extends S3Emitter {
     }
 
     @Override
-    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
-        List<byte[]> failed = super.emit(buffer);
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer, final String shardId) throws IOException {
+        List<byte[]> failed = super.emit(buffer, shardId);
         if (!failed.isEmpty()) {
             return buffer.getRecords();
         }

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/redshift/RedshiftManifestEmitter.java
@@ -105,7 +105,7 @@ public class RedshiftManifestEmitter implements IEmitter<String> {
     }
 
     @Override
-    public List<String> emit(final UnmodifiableBuffer<String> buffer) throws IOException {
+    public List<String> emit(final UnmodifiableBuffer<String> buffer, final String shardId) throws IOException {
         List<String> records = buffer.getRecords();
         Connection conn = null;
 

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3Emitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3Emitter.java
@@ -62,7 +62,7 @@ public class S3Emitter implements IEmitter<byte[]> {
     }
 
     @Override
-    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer, final String shardId) throws IOException {
         List<byte[]> records = buffer.getRecords();
         // Write all of the records to a compressed output stream
         ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3ManifestEmitter.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/s3/S3ManifestEmitter.java
@@ -58,10 +58,10 @@ public class S3ManifestEmitter extends S3Emitter {
     }
 
     @Override
-    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer) throws IOException {
+    public List<byte[]> emit(final UnmodifiableBuffer<byte[]> buffer, final String shardId) throws IOException {
         // Store the contents of buffer.getRecords because superclass will
         // clear the buffer on success
-        List<byte[]> failed = super.emit(buffer);
+        List<byte[]> failed = super.emit(buffer, shardId);
         // calls S3Emitter to write objects to Amazon S3
         if (!failed.isEmpty()) {
             return buffer.getRecords();

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessorTests.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessorTests.java
@@ -16,10 +16,7 @@ package com.amazonaws.services.kinesis.connectors;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Properties;
+import java.util.*;
 
 import org.easymock.EasyMock;
 import org.easymock.IMocksControl;
@@ -159,7 +156,7 @@ public class KinesisConnectorRecordProcessorTests {
 
         // Emitter behavior:
         // one call to emit
-        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class))).andReturn(
+        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class), "-shardId-")).andReturn(
                 Collections.emptyList());
 
         // Checkpointer Behavior:
@@ -223,7 +220,7 @@ public class KinesisConnectorRecordProcessorTests {
 
         // Emitter behavior:
         // one call to emit
-        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class))).andThrow(
+        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class), "-shardId-")).andThrow(
                 new IOException());
         emitter.fail(EasyMock.anyObject(List.class));
         EasyMock.expectLastCall();
@@ -299,7 +296,7 @@ public class KinesisConnectorRecordProcessorTests {
 
         // Emitter behavior:
         // one call to emit
-        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class))).andReturn(
+        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class), "-shardId-")).andReturn(
                 Collections.emptyList());
 
         // Checkpointer Behavior:
@@ -370,10 +367,10 @@ public class KinesisConnectorRecordProcessorTests {
 
         // uses the original list (i.e. emitItems)
         UnmodifiableBuffer<Object> unmodBuffer = new UnmodifiableBuffer<>(buffer, objectsAsList);
-        EasyMock.expect(emitter.emit(EasyMock.eq(unmodBuffer))).andReturn(singleObjectAsList);
+        EasyMock.expect(emitter.emit(EasyMock.eq(unmodBuffer), "-shardId-")).andReturn(singleObjectAsList);
         // uses the returned list (i.e. unprocessed)
         unmodBuffer = new UnmodifiableBuffer<>(buffer, singleObjectAsList);
-        EasyMock.expect(emitter.emit(EasyMock.eq(unmodBuffer))).andReturn(Collections.emptyList());
+        EasyMock.expect(emitter.emit(EasyMock.eq(unmodBuffer), "-shardId-")).andReturn(Collections.emptyList());
 
         // Done, so expect buffer clear and checkpoint
         buffer.getLastSequenceNumber();
@@ -445,7 +442,7 @@ public class KinesisConnectorRecordProcessorTests {
 
         // uses the original list (i.e. emitItems)
         UnmodifiableBuffer<Object> unmodBuffer = new UnmodifiableBuffer<>(buffer, objectsAsList);
-        EasyMock.expect(emitter.emit(EasyMock.eq(unmodBuffer))).andReturn(singleObjectAsList);
+        EasyMock.expect(emitter.emit(EasyMock.eq(unmodBuffer), "-shardId-")).andReturn(singleObjectAsList);
 
         // only one retry, so now we should expect fail to be called.
         emitter.fail(singleObjectAsList);
@@ -526,7 +523,7 @@ public class KinesisConnectorRecordProcessorTests {
         // expect flush cycle.
         // Get records from buffer, emit, clear, then checkpoint
         EasyMock.expect(buffer.getRecords()).andReturn(Collections.emptyList());
-        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class))).andReturn(
+        EasyMock.expect(emitter.emit(EasyMock.anyObject(UnmodifiableBuffer.class), "-shardId-")).andReturn(
                 Collections.emptyList());
         buffer.getLastSequenceNumber();
         EasyMock.expectLastCall().andReturn(null);

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessorTests.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessorTests.java
@@ -137,7 +137,7 @@ public class KinesisConnectorRecordProcessorTests {
 
         // Buffer Behavior:
         // consume numRecords dummy records
-        buffer.consumeRecord(o, buf, EasyMock.anyObject(String.class));
+        buffer.consumeRecord(o, buf, EasyMock.anyObject(String.class), new Date());
         EasyMock.expectLastCall().times(numRecords);
         buffer.getLastSequenceNumber();
         EasyMock.expectLastCall().andReturn(DEFAULT_SEQUENCE_NUMBER);
@@ -209,7 +209,7 @@ public class KinesisConnectorRecordProcessorTests {
 
         // Buffer Behavior:
         // consume numRecords dummy records
-        buffer.consumeRecord(o, buf, seq);
+        buffer.consumeRecord(o, buf, seq, new Date());
         EasyMock.expectLastCall().times(numRecords);
 
         // check full buffer and return true
@@ -281,7 +281,7 @@ public class KinesisConnectorRecordProcessorTests {
 
         // Buffer Behavior:
         // consume numRecords dummy records
-        buffer.consumeRecord(o, buf, EasyMock.anyObject(String.class));
+        buffer.consumeRecord(o, buf, EasyMock.anyObject(String.class), new Date());
         EasyMock.expectLastCall().times(numTotalRecords);
         buffer.getLastSequenceNumber();
         EasyMock.expectLastCall().andReturn(DEFAULT_SEQUENCE_NUMBER);
@@ -347,11 +347,11 @@ public class KinesisConnectorRecordProcessorTests {
         // set expectations for each record
         EasyMock.expect(transformer.toClass(EasyMock.anyObject(Record.class))).andReturn(dummyRecord1);
         EasyMock.expect(filter.keepRecord(dummyRecord1)).andReturn(true);
-        buffer.consumeRecord(dummyRecord1, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER);
+        buffer.consumeRecord(dummyRecord1, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER, new Date());
 
         EasyMock.expect(transformer.toClass(EasyMock.anyObject(Record.class))).andReturn(dummyRecord2);
         EasyMock.expect(filter.keepRecord(dummyRecord2)).andReturn(true);
-        buffer.consumeRecord(dummyRecord2, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER);
+        buffer.consumeRecord(dummyRecord2, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER, new Date());
 
         EasyMock.expect(buffer.shouldFlush()).andReturn(true);
 
@@ -422,11 +422,11 @@ public class KinesisConnectorRecordProcessorTests {
         // set expectations for each record
         EasyMock.expect(transformer.toClass(EasyMock.anyObject(Record.class))).andReturn(dummyRecord1);
         EasyMock.expect(filter.keepRecord(dummyRecord1)).andReturn(true);
-        buffer.consumeRecord(dummyRecord1, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER);
+        buffer.consumeRecord(dummyRecord1, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER, new Date());
 
         EasyMock.expect(transformer.toClass(EasyMock.anyObject(Record.class))).andReturn(dummyRecord2);
         EasyMock.expect(filter.keepRecord(dummyRecord2)).andReturn(true);
-        buffer.consumeRecord(dummyRecord2, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER);
+        buffer.consumeRecord(dummyRecord2, DEFAULT_RECORD_BYTE_SIZE, DEFAULT_SEQUENCE_NUMBER, new Date());
 
         EasyMock.expect(buffer.shouldFlush()).andReturn(true);
 

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBufferTests.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/UnmodifiableBufferTests.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.kinesis.connectors;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.easymock.EasyMock;
@@ -74,7 +75,7 @@ public class UnmodifiableBufferTests {
 
         // Expect exceptions on the following operations
         exception.expect(UnsupportedOperationException.class);
-        umb.consumeRecord(1, 1, "");
+        umb.consumeRecord(1, 1, "", new Date());
 
         exception.expect(UnsupportedOperationException.class);
         umb.clear();

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/elasticsearch/ElasticsearchEmitterTest.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/elasticsearch/ElasticsearchEmitterTest.java
@@ -166,7 +166,7 @@ public class ElasticsearchEmitterTest {
 
         replay(elasticsearchClientMock, buffer, mockBulkBuilder, mockIndexBuilder, mockFuture, mockBulkResponse);
 
-        List<ElasticsearchObject> failures = emitter.emit(buffer);
+        List<ElasticsearchObject> failures = emitter.emit(buffer, "-shardId-");
         assertTrue(failures.isEmpty());
 
         verify(elasticsearchClientMock, buffer, mockBulkBuilder, mockIndexBuilder, mockFuture, mockBulkResponse);
@@ -198,7 +198,7 @@ public class ElasticsearchEmitterTest {
         replay(elasticsearchClientMock, r1, r2, r3, buffer, mockBulkBuilder, mockIndexBuilder, mockFuture,
                 mockBulkResponse);
 
-        List<ElasticsearchObject> failures = emitter.emit(buffer);
+        List<ElasticsearchObject> failures = emitter.emit(buffer, "-shardId-");
         assertTrue(failures.isEmpty());
 
         verify(elasticsearchClientMock, r1, r2, r3, buffer, mockBulkBuilder, mockIndexBuilder, mockFuture,
@@ -265,7 +265,7 @@ public class ElasticsearchEmitterTest {
                 mockBulkResponse, mockAdminClient, mockClusterAdminClient, mockHealthRequestBuilder, mockHealthFuture,
                 mockResponse);
 
-        List<ElasticsearchObject> failures = emitter.emit(buffer);
+        List<ElasticsearchObject> failures = emitter.emit(buffer, "-shardId-");
         assertTrue(failures.size() == 1);
         // the emitter should return the exact object that failed
         assertEquals(failures.get(0), records.get(1));
@@ -314,7 +314,7 @@ public class ElasticsearchEmitterTest {
         replay(elasticsearchClientMock, r1, r2, r3, buffer, mockBulkBuilder, mockIndexBuilder, mockFuture,
                 mockBulkResponse);
 
-        List<ElasticsearchObject> failures = emitter.emit(buffer);
+        List<ElasticsearchObject> failures = emitter.emit(buffer, "-shardId-");
         assertTrue(failures.isEmpty());
 
         verify(elasticsearchClientMock, r1, r2, r3, buffer, mockBulkBuilder, mockIndexBuilder, mockFuture,

--- a/src/test/java/com/amazonaws/services/kinesis/connectors/impl/BasicMemoryBufferTests.java
+++ b/src/test/java/com/amazonaws/services/kinesis/connectors/impl/BasicMemoryBufferTests.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 
@@ -64,7 +65,7 @@ public class BasicMemoryBufferTests {
         control.replay();
         BasicMemoryBuffer<Integer> buffer = new BasicMemoryBuffer<Integer>(config);
         for (i = 0; i < iters; i++) {
-            buffer.consumeRecord(i, 1, Integer.toString(i));
+            buffer.consumeRecord(i, 1, Integer.toString(i), new Date());
         }
         control.verify();
 
@@ -102,7 +103,7 @@ public class BasicMemoryBufferTests {
         BasicMemoryBuffer<Integer> buffer = new BasicMemoryBuffer<Integer>(config);
         for (i = 0; i < iters; i++) {
             assertFalse("Failed at count " + i, buffer.shouldFlush());
-            buffer.consumeRecord(i, recordSize, Integer.toString(i));
+            buffer.consumeRecord(i, recordSize, Integer.toString(i), new Date());
         }
         control.verify();
         assertTrue(buffer.shouldFlush());
@@ -120,7 +121,7 @@ public class BasicMemoryBufferTests {
         buffer2.clear();
         // put in one records so that neither record count limit nor byte size limit is 
         // reached but buffer is not empty
-        buffer2.consumeRecord(1, 1, "1"); 
+        buffer2.consumeRecord(1, 1, "1", new Date());
         assertFalse(buffer2.shouldFlush());
         assertFalse(buffer2.shouldFlush());
         assertTrue(buffer2.shouldFlush());


### PR DESCRIPTION
shardId is handy for checkpointing, and approximateArrivalTime can be used e.g. as part of the S3 key