### PR TITLE
Fix checkpointing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>amazon-kinesis-connectors</artifactId>
     <packaging>jar</packaging>
     <name>Amazon Kinesis Connector Library</name>
-    <version>1.3.0-IFLIX1</version>
+    <version>1.3.0-IFLIX2</version>
     <description>The Amazon Kinesis Connector Library helps Java developers integrate Amazon Kinesis with other AWS and non-AWS services.</description>
     <url>https://aws.amazon.com/kinesis</url>
 

--- a/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
+++ b/src/main/java/com/amazonaws/services/kinesis/connectors/KinesisConnectorRecordProcessor.java
@@ -175,17 +175,19 @@ public class KinesisConnectorRecordProcessor<T, U> implements IRecordProcessor {
             }
             if (!unprocessed.isEmpty()) {
                 emitter.fail(unprocessed);
-            }
-            final String lastSequenceNumberProcessed = buffer.getLastSequenceNumber();
-            buffer.clear();
-            // checkpoint once all the records have been consumed
-            if (lastSequenceNumberProcessed != null) {
-                checkpointer.checkpoint(lastSequenceNumberProcessed);
+            } else {
+                // checkpoint once all the records have been successfully processed
+                final String lastSequenceNumberProcessed = buffer.getLastSequenceNumber();
+                if (lastSequenceNumberProcessed != null) {
+                    checkpointer.checkpoint(lastSequenceNumberProcessed);
+                }
             }
         } catch (IOException | KinesisClientLibDependencyException | InvalidStateException | ThrottlingException
                 | ShutdownException e) {
             LOG.error(e);
             emitter.fail(unprocessed);
+        } finally {
+            buffer.clear();
         }
     }
 


### PR DESCRIPTION
We want to checkpoint only when we have successfully processed everything in the buffer. We don't want to checkpoint when there are unprocessed stuff. Also we want to clear the buffer when we're done, in any case.